### PR TITLE
 Add Pull Request Template for contributors (Fixes #6)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+#  Pull Request Template
+
+##  Description / Motivation
+<!-- Explain the purpose of this PR. What issue does it solve or feature does it add? -->
+
+Fixes #[ISSUE_NUMBER] <!-- Replace with the related issue number -->
+
+---
+
+##  Type of Change
+<!-- Please select all that apply -->
+
+- [ ]  Bug Fix  
+- [ ]  New Feature  
+- [ ]  Code Refactor  
+- [ ]  Documentation Update  
+- [ ]  CI/CD or Workflow Update  
+
+---
+
+##  Testing Details
+<!-- Describe how you tested your changes -->
+
+- [ ] Code compiles successfully  
+- [ ] Tests added / updated  
+- [ ] All tests passing locally  
+- [ ] Verified on Codespace or local environment  
+
+---
+
+##  Screenshots (if applicable)
+<!-- Add screenshots or GIFs to show visual changes (UI, dashboards, etc.) -->
+
+---
+
+##  Checklist
+- [ ] My code follows the repository’s coding guidelines  
+- [ ] I have run linting (e.g., `black`, `isort`) before committing  
+- [ ] I have added tests that prove my fix or feature works  
+- [ ] I have updated documentation (if necessary)  
+- [ ] This PR is ready for review  
+
+---
+
+###  Additional Notes
+<!-- Anything else reviewers should know? -->


### PR DESCRIPTION
### Description
This PR adds a Pull Request template under `.github/pull_request_template.md`.

### Features
- Provides clear structure for PRs (Description, Type, Testing, Checklist).
- Encourages consistent formatting and better collaboration.
- Saves maintainers time during reviews.

### Related Issue
Fixes #6 

### Checklist
- [x] Template added under `.github/`
- [x] Syntax verified
- [x] Linked to issue #6 
- [x] Hacktoberfest labels applied
